### PR TITLE
[Feat] 버튼컴포넌트 hover/active 공통속성지정

### DIFF
--- a/src/app/(stack)/register/ox-test/components/OXQuiz.tsx
+++ b/src/app/(stack)/register/ox-test/components/OXQuiz.tsx
@@ -132,7 +132,6 @@ function OXQuiz() {
           onClick={goBack}
           disabled={current === 0}
           aria-label="이전문제로 이동"
-          className="enabled:hover:shadow-2xl enabled:hover:scale-y-105 enabled:hover:ring-4 enabled:hover:ring-darkgreen-default enabled:active:shadow-2xl enabled:active:scale-y-105 enabled:active:ring-4 enabled:active:ring-darkgreen-default"
         >
           이전
         </Button>
@@ -143,7 +142,6 @@ function OXQuiz() {
           aria-label={
             current === questions.length - 1 ? "완료" : "다음문제로 이동"
           }
-          className="enabled:hover:shadow-2xl enabled:hover:scale-y-105 enabled:hover:ring-4 enabled:hover:ring-darkgreen-default enabled:active:shadow-2xl enabled:active:scale-y-105 enabled:active:ring-4 enabled:active:ring-darkgreen-default"
         >
           {current === questions.length - 1 ? "완료" : "다음"}
         </Button>

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -9,7 +9,7 @@ import { cva, VariantProps } from "class-variance-authority";
 const buttonVariants = cva(
   /* 공통스타일지정 
     rounded 8px, inline-flex, 가운데정렬, disabled : 커서🚫 color 변할 때 자연스럽게 변하도록(duration-150) 드래그 x 기본커서 : pointer 포커스되면 ring-2 disabled 색 gray&폰트 dark-gray font-bold*/
-  "rounded-lg  inline-flex shrink-0 items-center justify-center disabled:cursor-not-allowed transition-colors duration-150 select-none cursor-pointer focus-visible:ring-2 disabled:bg-gray disabled:text-darkgray font-bold ",
+  "rounded-lg  inline-flex shrink-0 items-center justify-center disabled:cursor-not-allowed transition-colors duration-150 select-none cursor-pointer focus-visible:ring-2 disabled:bg-gray disabled:text-darkgray font-bold enabled:hover:shadow-2xl enabled:hover:scale-y-105 enabled:hover:ring-4 enabled:hover:ring-darkgreen-default enabled:active:shadow-2xl enabled:active:scale-y-105 enabled:active:ring-4 enabled:active:ring-darkgreen-default",
   {
     variants: {
       size: {


### PR DESCRIPTION
### 🛠️ 작업 개요
버튼 컴포넌트 hover/active 상태에서 적용될 css를 공통으로 지정했습니다.
- border(ring) 
- scaleY-105
- shadow 지정

### ✏️ 작업 내용

- 버튼컴포넌트 수정

### #️⃣ 관련 이슈

### 🗣️ 테스트 결과 보고
