### PR TITLE
[Feat] 채팅방 생성 api 연결, 생성된 채팅방으로 라우팅 기능구현 

### DIFF
--- a/src/api/createChatRoom.ts
+++ b/src/api/createChatRoom.ts
@@ -1,0 +1,43 @@
+
+export const createChatRoom = async (
+  category:string,
+  title:string,
+  target:string
+  ) => {
+  let endpoint;
+  //target이 ai,mentor일 때 endpoint 구분
+  if(target === 'ai'){
+    endpoint = 'http://localhost:8080/api/v1/chat/ai/room';
+  }else{
+    endpoint = 'http://localhost:8080/api/v1/chat/mentor/mentee/room';
+  }
+ 
+  try{
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify({
+        title, //=> content나 question이 들어가야할 듯함
+        category,
+      }),
+    });
+
+    if(!res.ok){
+      throw new Error('채팅방 생성 실패했습니다.');
+    }
+
+    const json = await res.json();
+
+    return {id:json.data.id};
+    
+
+  }catch(e){
+    if(e instanceof Error){
+      throw new Error(e.message);
+    }
+    throw new Error('채팅방 생성 실패했습니다.');
+  }
+};

--- a/src/app/(stack)/chat/create/components/CreateChatForm.tsx
+++ b/src/app/(stack)/chat/create/components/CreateChatForm.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import StepCategory from "./StepCategory";
 import StepQuestion from "./StepQuestion";
 import StepTarget from "./StepTarget";
+import { createChatRoom } from "@/api/createChatRoom";
+import { useRouter } from "next/navigation";
 
 
 type ChatFormData = {
@@ -19,9 +21,25 @@ export default function CreateChatForm() {
     question: "",
     target: "",
   });
+  const router = useRouter();
 
   const next = () => setStep((s) => s + 1);
 
+  const handleSubmit = async() => {
+
+    try{
+      const {id} = await createChatRoom(
+        formData.category,//카테고리
+        formData.question,//질문
+        formData.target //질문 대상
+      );
+
+      console.log("채팅방생성완료", id); // 추후 console 지우기
+      router.push(`/chat/${id}`) ;
+    }catch(e){
+      alert(e);
+    }
+  }
   return (
     <>
       {step === 0 && (
@@ -42,10 +60,7 @@ export default function CreateChatForm() {
         <StepTarget
           value={formData.target}
           onSelect={(target) => setFormData({ ...formData, target })}
-          onSubmit={() => {
-            console.log("채팅방생성완료", formData); //추후에 console 지우기
-            // TODO: API 호출 →채팅방 ID 응답-> /chat/[id] 이동
-          }}
+          onSubmit={handleSubmit}
         />
       )}
     </>

--- a/src/app/(stack)/chat/create/components/StepTarget.tsx
+++ b/src/app/(stack)/chat/create/components/StepTarget.tsx
@@ -16,16 +16,16 @@ function StepTarget({value, onSelect,onSubmit}: StepTargetProps) {
        <div className="flex flex-col w-full gap-8">
         <Button 
           fullWidth
-          onClick={()=> onSelect("Mentor")}
-          className={value === "Mentor" ? "bg-green-hover ring-4 ring-darkgreen-default" : ""}
+          onClick={()=> onSelect("mentor")}
+          className={value === "mentor" ? "bg-green-hover ring-4 ring-darkgreen-default" : ""}
         >
           멘토에게 질문하기
         </Button>
 
         <Button 
           fullWidth
-          onClick={()=> onSelect("AI")}
-          className={`mb-25 ${value === "AI" ? "bg-green-hover ring-4 ring-darkgreen-default" : ""}`}
+          onClick={()=> onSelect("ai")}
+          className={`mb-25 ${value === "ai" ? "bg-green-hover ring-4 ring-darkgreen-default" : ""}`}
         >
           AI에게 질문하기
         </Button>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,11 +16,11 @@ export default function RootLayout({
   return (
     <html lang="ko-KR" className={pretendard.variable}>
       <body className={`antialiased`}>
-        {/* <AuthProvider> */}
+        <AuthProvider>
         <div className="m-auto max-w-[650px] min-w-[350px] h-dvh overflow-y-hidden">
           {children}
         </div>
-        {/* </AuthProvider> */}
+        </AuthProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
### 🛠️ 작업 개요
- 채팅방 생성 api 연결했습니다. 
  - 멘토 채팅방 생성은 api 아직 구현되지 않아 추후 연결 예정입니다.
- 생성된 채팅방id로 라우팅 기능 구현했습니다.
- `AuthProvider` 주석 해제했습니다.
### ✏️ 작업 내용
- 채팅방 생성 api 연결(AI/멘토 엔드포인트 분리)
- 채팅방 생성 성공시 응답으로 받은 `id`값을 이용해 해당 채팅방(`/chat/{id}`)로 이동 처리

### 🗣️ 테스트 결과 보고
- 채팅방 생성 요청 시 정상적으로 `id`가 응답됨을 확인
- 현재 멘토 채팅방 API는 아직 연동되지 않아 추후 연결 예정
- `AuthProvider`주석 해제 후 로그인 상태 유지되어 채팅방 생성 가능해짐